### PR TITLE
docs: fix simple typo, elimiate -> eliminate

### DIFF
--- a/pyvotecore/stv.py
+++ b/pyvotecore/stv.py
@@ -85,7 +85,7 @@ class STV(MultipleWinnerVotingSystem):
                     # Remove candidates from remaining ballots
                     ballots = self.remove_candidates_from_ballots(round["winners"], ballots)
 
-                # If no candidate exceeds the quota, elimiate the least preferred
+                # If no candidate exceeds the quota, eliminate the least preferred
                 else:
                     round.update(self.loser(round["tallies"]))
                     remaining_candidates.remove(round["loser"])


### PR DESCRIPTION
There is a small typo in pyvotecore/stv.py.

Should read `eliminate` rather than `elimiate`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md